### PR TITLE
Map over the parkruns once, not three times

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                  [enlive "1.1.6"]
-                  [ring "1.6.0"]
-                  [net.cgrand/moustache "1.1.0"]
-                  [org.clojure/java.jdbc "0.4.2"]
-                  [org.clojure/data.json "0.2.6"]
-                  [clj-http "3.5.0"]])
+                 [enlive "1.1.6"]])

--- a/src/parkrun_app/core.clj
+++ b/src/parkrun_app/core.clj
@@ -1,7 +1,5 @@
 (ns parkrun-app.core
-  (:require [clojure.string :as string]
-            [net.cgrand.enlive-html :as html]
-            [clj-http.client :as http]))
+  (:require [net.cgrand.enlive-html :as html]))
 
 (defn fetch-url [url]
   (html/html-resource (java.net.URL. url)))

--- a/src/parkrun_app/core.clj
+++ b/src/parkrun_app/core.clj
@@ -32,23 +32,19 @@
 
 (defn extract-data
   [dates]
-  (let [parkrun (html/select (second (first dates)) [:li])]
-    ((juxt (partial map #(->> %
-                        (:content)
-                        (second)))
-           (partial map #(->> %
-                        (:content)
-                        (first)
-                        (:attrs)
-                        (:href)))
-           (partial map #(->> %
-                        (:content)
-                        (first)
-                        (:content)
-                        (first)))) parkrun)))
+  (let [parkruns (html/select (second (first dates)) [:li])]
+    (map (juxt #(->> %
+                     (:content)
+                     (second))
+               #(->> %
+                     (:content)
+                     (first)
+                     (:attrs)
+                     (:href))
+               #(->> %
+                      (:content)
+                      (first)
+                      (:content)
+                      (first))) parkruns)))
 
 (extract-data dates)
-
-(partition 3 (apply interleave (extract-data dates)))
-
-dates


### PR DESCRIPTION
I realised after the dojo we were mapping three times instead of once. Also rename `parkrun` to `parkruns` — this probably added to the confusion.